### PR TITLE
Adjust jobs notebook

### DIFF
--- a/backend/jobs.py
+++ b/backend/jobs.py
@@ -82,7 +82,6 @@ def form_event_and_send_to_control(d, dbutils, spark):
 
 def process(data, spark, dbutils):
     try:
-        #data = get_widget_values(dbutils)
         validated_data = validate_widget_values(data, dbutils, spark)
         enriched_data = enrich_widget_values(validated_data, spark)
         form_event_and_send_to_control(enriched_data, dbutils, spark) and dbutils.displayHTML("<h1>Request sent.</h1>")    

--- a/backend/jobs.py
+++ b/backend/jobs.py
@@ -80,9 +80,9 @@ def enrich_widget_values(d, spark):
 def form_event_and_send_to_control(d, dbutils, spark):
     return common.form_event_and_send_to_control(d, "JOB", dbutils, spark)
 
-def process(spark, dbutils):
+def process(data, spark, dbutils):
     try:
-        data = get_widget_values(dbutils)
+        #data = get_widget_values(dbutils)
         validated_data = validate_widget_values(data, dbutils, spark)
         enriched_data = enrich_widget_values(validated_data, spark)
         form_event_and_send_to_control(enriched_data, dbutils, spark) and dbutils.displayHTML("<h1>Request sent.</h1>")    

--- a/backend/jobs.py
+++ b/backend/jobs.py
@@ -80,7 +80,7 @@ def enrich_widget_values(d, spark):
 def form_event_and_send_to_control(d, dbutils, spark):
     return common.form_event_and_send_to_control(d, "JOB", dbutils, spark)
 
-def process(dbutils, spark):
+def process(spark, dbutils):
     try:
         data = get_widget_values(dbutils)
         validated_data = validate_widget_values(data, dbutils, spark)

--- a/create_job.py
+++ b/create_job.py
@@ -4,7 +4,7 @@ jobs.display_widgets(spark, dbutils)
 
 # COMMAND ----------
 
-data = get_widget_values(dbutils)
+data = jobs.get_widget_values(dbutils)
 
 # COMMAND ----------
 

--- a/create_job.py
+++ b/create_job.py
@@ -4,4 +4,8 @@ jobs.display_widgets(spark, dbutils)
 
 # COMMAND ----------
 
-jobs.process(spark, dbutils)
+data = get_widget_values(dbutils)
+
+# COMMAND ----------
+
+jobs.process(data, spark, dbutils)

--- a/create_job.py
+++ b/create_job.py
@@ -1,11 +1,7 @@
 # Databricks notebook source
 from backend import jobs
-jobs.process(dbutils, spark)
-
-# COMMAND ----------
-
-dbutils.widgets.removeAll()
-
-# COMMAND ----------
-
 jobs.display_widgets(spark, dbutils)
+
+# COMMAND ----------
+
+jobs.process(spark, dbutils)


### PR DESCRIPTION
Jobs notebook behavior is now consistent - cell order updated so that displaying widgets is the first cell, and a request is no longer sent after every widget change.