### PR TITLE
Adjusted order of cells

### DIFF
--- a/approve_code.py
+++ b/approve_code.py
@@ -1,5 +1,12 @@
 # Databricks notebook source
+dbutils.widgets.removeAll()
+
+# COMMAND ----------
+
 from backend import approvals
+approvals.display_widgets(spark, dbutils)
+
+# COMMAND ----------
 
 try:
     data = approvals.get_widget_values(dbutils)
@@ -11,11 +18,11 @@ except Exception as e:
 
 # COMMAND ----------
 
-dbutils.widgets.removeAll()
+
 
 # COMMAND ----------
 
-approvals.display_widgets(spark, dbutils)
+
 
 # COMMAND ----------
 


### PR DESCRIPTION
To re-load the widgets to get an updated code list, the users will have to individually execute the remove cell followed by the load widget cell.  After they select their code and approval, they'll only execute the last cell.