### PR TITLE
added display; changed order of cells

### DIFF
--- a/approve_code.py
+++ b/approve_code.py
@@ -3,11 +3,6 @@ dbutils.widgets.removeAll()
 
 # COMMAND ----------
 
-from backend import approvals
-approvals.display_widgets(spark, dbutils)
-
-# COMMAND ----------
-
 try:
     data = approvals.get_widget_values(dbutils)
     validated_data = approvals.validate_widget_values(data, dbutils, spark)
@@ -18,12 +13,10 @@ except Exception as e:
 
 # COMMAND ----------
 
-
-
-# COMMAND ----------
-
-
+from backend import approvals
+df = approvals.display_widgets(spark, dbutils)
 
 # COMMAND ----------
 
-
+# DBTITLE 1,Review pending request details
+display(df)

--- a/approve_code.py
+++ b/approve_code.py
@@ -3,17 +3,26 @@ dbutils.widgets.removeAll()
 
 # COMMAND ----------
 
+from backend import approvals
+data = None
 try:
     data = approvals.get_widget_values(dbutils)
-    validated_data = approvals.validate_widget_values(data, dbutils, spark)
-    enriched_data = approvals.enrich_widget_values(validated_data, spark)
-    approvals.form_event_and_send_to_control(enriched_data, dbutils, spark) and displayHTML("<h1>Request sent.</h1>")    
 except Exception as e:
     if not "InputWidgetNotDefined" in str(e): print(e) 
 
 # COMMAND ----------
 
 from backend import approvals
+try:
+    if (data != None):
+        validated_data = approvals.validate_widget_values(data, dbutils, spark)
+        enriched_data = approvals.enrich_widget_values(validated_data, spark)
+        approvals.form_event_and_send_to_control(enriched_data, dbutils, spark) and displayHTML("<h1>Request sent.</h1>") 
+except Exception as e:
+    if not "InputWidgetNotDefined" in str(e): print(e) 
+
+# COMMAND ----------
+
 df = approvals.display_widgets(spark, dbutils)
 
 # COMMAND ----------

--- a/approve_code.py
+++ b/approve_code.py
@@ -12,7 +12,6 @@ except Exception as e:
 
 # COMMAND ----------
 
-from backend import approvals
 try:
     if (data != None):
         validated_data = approvals.validate_widget_values(data, dbutils, spark)

--- a/backend/approvals.py
+++ b/backend/approvals.py
@@ -30,18 +30,19 @@ def get_open_code_reviews(spark, dbutils):
         dbutils.displayHTML("""
                 <div style="color:red;font-size:28pt">There are no pending code requests. Please check back later.</div>
             """)
-        return [""]
+        return ([""], df)
     else:
         choices = [x.name for x in pending]
-        return choices   
+        return (choices, df)
     
 
 # display_widgets
 def display_widgets(spark, dbutils):
     dbutils.widgets.dropdown(name="00_action", defaultValue="REVIEWING", choices=['REVIEWING', 'APPROVE', 'REJECT'])
-    code_choices=get_open_code_reviews(spark, dbutils)
+    (code_choices, df) = get_open_code_reviews(spark, dbutils)
     dbutils.widgets.multiselect(name="01_code_name", defaultValue=code_choices[0], choices=code_choices)
     dbutils.widgets.text(name="02_reason", defaultValue="")
+    return df
 
 def get_widget_values(dbutils):
     widget_names = ["action", "code_name", "reason"]


### PR DESCRIPTION
See this comment: https://github.com/christophergrant/clean-notebooks/commit/ef525db6f3ead9a33460f55848490d65a603d76e#commitcomment-75366474

By having the display happen after form_event_and_send_to_control, approved/rejected code items (from previous nb run) will disappear from the drop-down and review list.

I also added a display for the pending code request.